### PR TITLE
Explicitly specify macos arch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,4 +25,6 @@ jobs:
         id: example
         run: |
           cd ./example
+          # Github Action runners do not support M1 yet.
+          nix run nixpkgs#sd mkARMMacosSystem mkIntelMacosSystem flake.nix
           ./test.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,6 @@ jobs:
   tests:
     strategy:
       matrix:
-        # TODO: Add macos-latest after https://github.com/srid/nixos-flake/issues/4
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         # TODO: Add macos-latest after https://github.com/srid/nixos-flake/issues/4
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ The `flakeModule` (flake-parts module) contains the following:
 In addition, all modules implicitly receive the following `specialArgs`:
 
 - `flake@{inputs, config}` (corresponding to flake-parts' arguments)
-- `system` (the system type, e.g. `x86_64-linux`)
 - `rosettaPkgs` (if on darwin)
 
 The module API will be heavily refactored over the coming days/weeks. DO NOT USE THIS PROJECT YET.

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -64,7 +64,7 @@
 
           # Configurations for a single macOS machine (using nix-darwin)
           darwinConfigurations = {
-            default = self.lib.mkMacosSystem {
+            default = self.lib.mkARMMacosSystem {
               imports = [
                 self.darwinModules.home-manager
                 # Your configuration.nix goes here

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -13,7 +13,7 @@
 
   outputs = inputs@{ self, ... }:
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = [ "x86_64-linux" "aarch64-darwin" ];
+      systems = [ "x86_64-linux" "aarch64-darwin" "x86_64-darwin" ];
       imports = [
         inputs.nixos-flake.flakeModule
       ];

--- a/example/test.sh
+++ b/example/test.sh
@@ -2,6 +2,8 @@ set -euo pipefail
 
 if [ "$(uname)" == "Darwin" ]; then
   CONF="darwinConfigurations.default"
+  # Github Action runners do not support M1 yet.
+  nix run nixpkgs#sd mkARMMacosSystem mkIntelMacosSystem
 else
   CONF="nixosConfigurations.example1"
 fi

--- a/example/test.sh
+++ b/example/test.sh
@@ -2,8 +2,6 @@ set -euo pipefail
 
 if [ "$(uname)" == "Darwin" ]; then
   CONF="darwinConfigurations.default"
-  # Github Action runners do not support M1 yet.
-  nix run nixpkgs#sd mkARMMacosSystem mkIntelMacosSystem
 else
   CONF="nixosConfigurations.example1"
 fi

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -8,11 +8,8 @@ let
     common = {
       flake = { inherit inputs config; };
     };
-    x86_64-linux = common // {
-      system = "x86_64-linux";
-    };
-    aarch64-darwin = common // {
-      system = "aarch64-darwin";
+    nixos = common;
+    darwin = common // {
       rosettaPkgs = import inputs.nixpkgs { system = "x86_64-darwin"; };
     };
   };
@@ -46,7 +43,7 @@ in
           ({
             home-manager.useGlobalPkgs = true;
             home-manager.useUserPackages = true;
-            home-manager.extraSpecialArgs = specialArgsFor.x86_64-linux;
+            home-manager.extraSpecialArgs = specialArgsFor.nixos;
           })
         ];
       };
@@ -57,23 +54,26 @@ in
           ({
             home-manager.useGlobalPkgs = true;
             home-manager.useUserPackages = true;
-            home-manager.extraSpecialArgs = specialArgsFor.aarch64-darwin;
+            home-manager.extraSpecialArgs = specialArgsFor.darwin;
           })
         ];
       };
-      lib = {
-        mkLinuxSystem = mod: inputs.nixpkgs.lib.nixosSystem rec {
+      lib = rec {
+        mkLinuxSystem = mod: inputs.nixpkgs.lib.nixosSystem {
           system = "x86_64-linux";
           # Arguments to pass to all modules.
-          specialArgs = specialArgsFor.${system};
+          specialArgs = specialArgsFor.nixos;
           modules = [ mod ];
         };
 
-        mkMacosSystem = mod: inputs.nix-darwin.lib.darwinSystem rec {
-          system = "aarch64-darwin";
-          specialArgs = specialArgsFor.${system};
+        mkMacosSystem = system: mod: inputs.nix-darwin.lib.darwinSystem {
+          inherit system;
+          specialArgs = specialArgsFor.darwin;
           modules = [ mod ];
         };
+
+        mkARMMacosSystem = mkMacosSystem "aarch64-darwin";
+        mkIntelMacosSystem = mkMacosSystem "x86_64-darwin";
       };
     };
 

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -95,7 +95,7 @@ in
             name = "activate";
             text =
               # TODO: Replace with deploy-rs or (new) nixinate
-              if system == "aarch64-darwin" then
+              if system == "aarch64-darwin" || system == "x86_64-darwin" then
                 ''
                   set -x
                   ${self.darwinConfigurations.default.system}/sw/bin/darwin-rebuild \


### PR DESCRIPTION
And remove `system` from specialArgs (it can be inferred from `pkgs.system` anyway).

The CI now builds for macos.

Resolves #4 