### PR TITLE
Fix `stateVersion` warnings in templates

### DIFF
--- a/examples/both/flake.nix
+++ b/examples/both/flake.nix
@@ -39,6 +39,7 @@
                     device = "/dev/disk/by-label/nixos";
                     fsType = "btrfs";
                   };
+                  system.stateVersion = "23.05";
                 })
                 # Your home-manager configuration
                 self.nixosModules.home-manager
@@ -63,7 +64,11 @@
                 self.nixosModules.common # See below for "nixosModules"!
                 self.nixosModules.darwin
                 # Your machine's configuration.nix goes here
-                ({ pkgs, ... }: { })
+                ({ pkgs, ... }: {
+                  # Used for backwards compatibility, please read the changelog before changing.
+                  # $ darwin-rebuild changelog
+                  system.stateVersion = 4;
+                })
                 # Your home-manager configuration
                 self.darwinModules.home-manager
                 {

--- a/examples/linux/flake.nix
+++ b/examples/linux/flake.nix
@@ -30,6 +30,7 @@
                 boot.loader.grub.device = "nodev";
                 fileSystems."/" = { device = "/dev/disk/by-label/nixos"; fsType = "btrfs"; };
                 users.users.${myUserName}.isNormalUser = true;
+                system.stateVersion = "23.05";
               })
               # Setup home-manager in NixOS config
               self.nixosModules.home-manager

--- a/examples/macos/flake.nix
+++ b/examples/macos/flake.nix
@@ -42,7 +42,6 @@
                 };
               }
             ];
-
           };
 
           # home-manager configuration goes here.

--- a/examples/macos/flake.nix
+++ b/examples/macos/flake.nix
@@ -29,6 +29,9 @@
               # Your nix-darwin configuration goes here
               ({ pkgs, ... }: {
                 security.pam.enableSudoTouchIdAuth = true;
+                # Used for backwards compatibility, please read the changelog before changing.
+                # $ darwin-rebuild changelog
+                system.stateVersion = 4;
               })
               # Setup home-manager in nix-darwin config
               self.darwinModules.home-manager
@@ -39,6 +42,7 @@
                 };
               }
             ];
+
           };
 
           # home-manager configuration goes here.


### PR DESCRIPTION
Add system.stateVersion to both nixos and darwin