### PR TITLE
Remove explicit 'system' argument

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,6 @@ jobs:
         id: examples
         run: |
           # Github Action runners do not support M1 yet.
-          nix run nixpkgs#sd 'nixpkgs.system = "aarch64-darwin"' 'nixpkgs.system = "x86_64-darwin"' ./examples/*/flake.nix
+          nix run nixpkgs#sd 'nixpkgs.hostPlatform = "aarch64-darwin"' 'nixpkgs.hostPlatform = "x86_64-darwin"' ./examples/*/flake.nix
 
           nix run nixpkgs#nixci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,6 @@ jobs:
         id: examples
         run: |
           # Github Action runners do not support M1 yet.
-          nix run nixpkgs#sd mkARMMacosSystem mkIntelMacosSystem ./examples/*/flake.nix
+          nix run nixpkgs#sd 'nixpkgs.system = "aarch64-darwin"' 'nixpkgs.system = "x86_64-darwin"' ./examples/*/flake.nix
 
-          nix run github:srid/nixci
+          nix run nixpkgs#nixci

--- a/examples/both/flake.nix
+++ b/examples/both/flake.nix
@@ -28,7 +28,7 @@
           nixosConfigurations = {
             # TODO: Change hostname from "example1" to something else.
             example1 = self.nixos-flake.lib.mkLinuxSystem {
-              nixpkgs.system = "x86_64-linux";
+              nixpkgs.hostPlatform = "x86_64-linux";
               imports = [
                 self.nixosModules.common # See below for "nixosModules"!
                 self.nixosModules.linux
@@ -61,7 +61,7 @@
           darwinConfigurations = {
             # TODO: Change hostname from "example1" to something else.
             example1 = self.nixos-flake.lib.mkMacosSystem {
-              nixpkgs.system = "aarch64-darwin";
+              nixpkgs.hostPlatform = "aarch64-darwin";
               imports = [
                 self.nixosModules.common # See below for "nixosModules"!
                 self.nixosModules.darwin

--- a/examples/both/flake.nix
+++ b/examples/both/flake.nix
@@ -27,7 +27,8 @@
           # Configurations for Linux (NixOS) machines
           nixosConfigurations = {
             # TODO: Change hostname from "example1" to something else.
-            example1 = self.nixos-flake.lib.mkLinuxSystem "x86_64-linux" {
+            example1 = self.nixos-flake.lib.mkLinuxSystem {
+              nixpkgs.system = "x86_64-linux";
               imports = [
                 self.nixosModules.common # See below for "nixosModules"!
                 self.nixosModules.linux
@@ -59,7 +60,8 @@
           # Configurations for macOS machines
           darwinConfigurations = {
             # TODO: Change hostname from "example1" to something else.
-            example1 = self.nixos-flake.lib.mkMacosSystem "aarch64-darwin" {
+            example1 = self.nixos-flake.lib.mkMacosSystem {
+              nixpkgs.system = "aarch64-darwin";
               imports = [
                 self.nixosModules.common # See below for "nixosModules"!
                 self.nixosModules.darwin

--- a/examples/linux/flake.nix
+++ b/examples/linux/flake.nix
@@ -22,7 +22,8 @@
         {
           # Configurations for Linux (NixOS) machines
           # TODO: Change hostname from "example1" to something else.
-          nixosConfigurations.example1 = self.nixos-flake.lib.mkLinuxSystem "x86_64-linux" {
+          nixosConfigurations.example1 = self.nixos-flake.lib.mkLinuxSystem {
+            nixpkgs.system = "x86_64-linux";
             imports = [
               # Your machine's configuration.nix goes here
               ({ pkgs, ... }: {

--- a/examples/linux/flake.nix
+++ b/examples/linux/flake.nix
@@ -23,7 +23,7 @@
           # Configurations for Linux (NixOS) machines
           # TODO: Change hostname from "example1" to something else.
           nixosConfigurations.example1 = self.nixos-flake.lib.mkLinuxSystem {
-            nixpkgs.system = "x86_64-linux";
+            nixpkgs.hostPlatform = "x86_64-linux";
             imports = [
               # Your machine's configuration.nix goes here
               ({ pkgs, ... }: {

--- a/examples/macos/flake.nix
+++ b/examples/macos/flake.nix
@@ -25,7 +25,7 @@
           # Configurations for macOS machines
           # TODO: Change hostname from "example1" to something else.
           darwinConfigurations.example1 = self.nixos-flake.lib.mkMacosSystem {
-            nixpkgs.system = "aarch64-darwin";
+            nixpkgs.hostPlatform = "aarch64-darwin";
             imports = [
               # Your nix-darwin configuration goes here
               ({ pkgs, ... }: {

--- a/examples/macos/flake.nix
+++ b/examples/macos/flake.nix
@@ -24,7 +24,8 @@
         {
           # Configurations for macOS machines
           # TODO: Change hostname from "example1" to something else.
-          darwinConfigurations.example1 = self.nixos-flake.lib.mkMacosSystem "aarch64-darwin" {
+          darwinConfigurations.example1 = self.nixos-flake.lib.mkMacosSystem {
+            nixpkgs.system = "aarch64-darwin";
             imports = [
               # Your nix-darwin configuration goes here
               ({ pkgs, ... }: {

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -59,7 +59,7 @@ in
                         let
                           # This is used just to pull out the `darwin-rebuild` script.
                           # See also: https://github.com/LnL7/nix-darwin/issues/613
-                          emptyConfiguration = self.nixos-flake.lib.mkMacosSystem system { };
+                          emptyConfiguration = self.nixos-flake.lib.mkMacosSystem { nixpkgs.system = system; };
                         in
                         ''
                           HOSTNAME=$(hostname -s)
@@ -129,15 +129,13 @@ in
       nixos-flake.lib = rec {
         inherit specialArgsFor;
 
-        mkLinuxSystem = system: mod: inputs.nixpkgs.lib.nixosSystem {
-          inherit system;
+        mkLinuxSystem = mod: inputs.nixpkgs.lib.nixosSystem {
           # Arguments to pass to all modules.
           specialArgs = specialArgsFor.nixos;
           modules = [ mod ];
         };
 
-        mkMacosSystem = system: mod: inputs.nix-darwin.lib.darwinSystem {
-          inherit system;
+        mkMacosSystem = mod: inputs.nix-darwin.lib.darwinSystem {
           specialArgs = specialArgsFor.darwin;
           modules = [ mod ];
         };

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -59,7 +59,7 @@ in
                         let
                           # This is used just to pull out the `darwin-rebuild` script.
                           # See also: https://github.com/LnL7/nix-darwin/issues/613
-                          emptyConfiguration = self.nixos-flake.lib.mkMacosSystem { nixpkgs.system = system; };
+                          emptyConfiguration = self.nixos-flake.lib.mkMacosSystem { nixpkgs.hostPlatform = system; };
                         in
                         ''
                           HOSTNAME=$(hostname -s)


### PR DESCRIPTION
The user can set it via `nixpkgs.system`