### PR TITLE
fix!: replace darwinModules default with a method

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -115,17 +115,6 @@ in
           })
         ];
       };
-      # macOS home-manager module
-      darwinModules.home-manager = {
-        imports = [
-          inputs.home-manager.darwinModules.home-manager
-          ({
-            home-manager.useGlobalPkgs = true;
-            home-manager.useUserPackages = true;
-            home-manager.extraSpecialArgs = specialArgsFor.darwin;
-          })
-        ];
-      };
       nixos-flake.lib = rec {
         inherit specialArgsFor;
 
@@ -138,6 +127,18 @@ in
         mkMacosSystem = mod: inputs.nix-darwin.lib.darwinSystem {
           specialArgs = specialArgsFor.darwin;
           modules = [ mod ];
+        };
+
+        mkMacosHomeManagerSystem = mod: inputs.nix-darwin.lib.darwinSystem {
+          specialArgs = specialArgsFor.darwin;
+          modules = [
+            inputs.home-manager.darwinModules.home-manager
+            ({
+              home-manager.useGlobalPkgs = true;
+              home-manager.useUserPackages = true;
+              home-manager.extraSpecialArgs = specialArgsFor.darwin;
+            })
+          ] ++[ mod ];
         };
 
         mkHomeConfiguration = pkgs: mod: inputs.home-manager.lib.homeManagerConfiguration {


### PR DESCRIPTION
Creating a PR to continue the conversation from https://github.com/srid/nixos-flake/discussions/27. 

My findings:

#### The existence of `darwinModules` in this flake as well as being defined in our own flakes causes a conflict at best, or a segfault at worst.

Out of the box you will get a segfault. Creating just a stub in `flake-module.nix` gives:

```bash
error: The option `flake.darwinModules' is defined multiple times while it's expected to be unique.

Definition values:
- In `/nix/store/sr93gdr5xg835syipdi25agf7smbi135-source/nixos-flake/flake-module.nix':
   {
     home-manager = { };
   }
- In `/nix/store/hjhx6dxw6jg1bxdj4w5raqr9cflxcjrn-source/nix-darwin':
   {
     default = {
       imports = [
         {
           users = {
   ...
Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions
```

My conclusion here was that the update to flake-parts changing the way inputs are passed in has affected the behaviour of which objects are referenced and when. Because of this it's no longer possible to define this in two places.

I realise this change I have made is not backwards compatible, though to have this work out of the box with the latest version of flake-parts I think it needs to happen. It could be avoided by changing the `darwinModules` name outside this flake like my first work around but then you still run into issues with people accidentally having a naming collision.

I figured the simplest thing I could do to make this work would just be to create a method that does what we need up front instead of supplying that value to it later. So that's what is in this PR.

I have only 1 week of experience with nix so far, so realise this PR is not likely up to scratch just yet. I'm happy to work on it with you - or for you to take over if that's what you'd prefer.

I've consumed the fix here and it all appears working for me: https://github.com/squirmy/nixos-config/commit/7ccecbf56a38c192823ef9903ea7ed1002ffc823

I believe that this is the key to fixing: https://github.com/srid/nixos-config/issues/31

