### PR TITLE
Rename to `darwinModules_` to workaround a flake-parts specific crash

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,4 +22,5 @@ jobs:
           # Github Action runners do not support M1 yet.
           nix run nixpkgs#sd 'nixpkgs.hostPlatform = "aarch64-darwin"' 'nixpkgs.hostPlatform = "x86_64-darwin"' ./examples/*/flake.nix
 
-          nix run nixpkgs#nixci
+          # nix run nixpkgs#nixci
+          nix run github:srid/nixci

--- a/doc/guide/module-outputs.md
+++ b/doc/guide/module-outputs.md
@@ -10,7 +10,7 @@ Importing the `nixos-flake` flake-parts module will autowire the following flake
 | ---------------------------- | ---------------------------------------------- |
 | `nixos-flake.lib`             | Functions `mkLinuxSystem`, `mkMacosSystem` and `mkHomeConfiguration` |
 | `nixosModules.home-manager`  | Home-manager setup module for NixOS            |
-| `darwinModules.home-manager` | Home-manager setup module for Darwin           |
+| `darwinModules_.home-manager` | Home-manager setup module for Darwin           |
 | `packages.update`            | Flake app to update key flake inputs            |
 | `packages.activate`          | Flake app to build & activate the system       |
 | `packages.activate-home`          | Flake app to build & activate the `homeConfigurations` for current user       |

--- a/examples/both/flake.nix
+++ b/examples/both/flake.nix
@@ -72,7 +72,7 @@
                   system.stateVersion = 4;
                 })
                 # Your home-manager configuration
-                self.darwinModules.home-manager
+                self.darwinModules_.home-manager
                 {
                   home-manager.users.${myUserName} = {
                     imports = [

--- a/examples/macos/flake.nix
+++ b/examples/macos/flake.nix
@@ -35,7 +35,7 @@
                 system.stateVersion = 4;
               })
               # Setup home-manager in nix-darwin config
-              self.darwinModules.home-manager
+              self.darwinModules_.home-manager
               {
                 home-manager.users.${myUserName} = {
                   imports = [ self.homeModules.default ];

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -116,7 +116,9 @@ in
         ];
       };
       # macOS home-manager module
-      darwinModules.home-manager = {
+      # This is named with an underscope, because flake-parts segfaults otherwise!
+      # See https://github.com/srid/nixos-config/issues/31
+      darwinModules_.home-manager = {
         imports = [
           inputs.home-manager.darwinModules.home-manager
           ({

--- a/flake.nix
+++ b/flake.nix
@@ -26,10 +26,11 @@
         };
       };
 
-    nixci = let overrideInputs = { nixos-flake = ./.; }; in {
+    nixci.default = let overrideInputs = { nixos-flake = ./.; }; in {
       macos = {
         inherit overrideInputs;
         dir = "examples/macos";
+        systems = [ "x86_64-darwin" "aarch64-darwin" ];
       };
       home = {
         inherit overrideInputs;
@@ -38,6 +39,7 @@
       linux = {
         inherit overrideInputs;
         dir = "examples/linux";
+        systems = [ "x86_64-linux" "aarch64-linux" ];
       };
       both = {
         inherit overrideInputs;


### PR DESCRIPTION
Closes #34, Closes #27
