### PR TITLE
chore(ci): Add `x86_64-*`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,16 +7,20 @@ on:
   pull_request:
 
 jobs:
+
   configure:
-    runs-on: self-hosted
+    runs-on: x86_64-linux
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
      - uses: actions/checkout@v4
      - id: set-matrix
-       run: echo "matrix=$(nixci gh-matrix --systems=aarch64-linux,aarch64-darwin | jq -c .)" >> $GITHUB_OUTPUT
+       run: echo "matrix=$(nixci gh-matrix --systems=x86_64-linux,x86_64-darwin,aarch64-darwin | jq -c .)" >> $GITHUB_OUTPUT
+  
   nix:
-    runs-on: self-hosted
+    runs-on: ${{ matrix.system }}
+    permissions:
+      contents: read
     needs: configure
     strategy:
       matrix: ${{ fromJson(needs.configure.outputs.matrix) }}
@@ -24,10 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          # My self hosted runner is ARM
-          sd \
-            'nixpkgs.hostPlatform = "x86_64-linux"' \
-            'nixpkgs.hostPlatform = "aarch64-linux"' \
-            ./examples/*/flake.nix
-
-          nixci build --systems "github:nix-systems/${{ matrix.system }}" .#default.${{ matrix.subflake}}
+          nixci \
+            --extra-access-tokens "github.com=${{ secrets.GITHUB_TOKEN }}" \
+            build \
+            --systems "github:nix-systems/${{ matrix.system }}" \
+            .#default.${{ matrix.subflake}}


### PR DESCRIPTION
## Access tokens

We also pass access-token to Nix to prevent github rate limits. This requires adding the following to the workflow file,

```yaml
    permissions:
      contents: read
```

and passing the following argument to `nixci:

```sh
--extra-access-tokens "github.com=${{ secrets.GITHUB_TOKEN }}"
```