### PR TITLE
`.#activate`: Simplify CLI by obviating the "host" sub-command

### DIFF
--- a/doc/activate.md
+++ b/doc/activate.md
@@ -35,7 +35,7 @@ Add the following to your configuration -- `nixosConfigurations.myhost` or `darw
 Then, you will be able to run the following to deploy to `myhost` from any machine:
 
 ```sh
-nix run .#activate host myhost
+nix run .#activate myhost
 ```
 
 ### Non-goals


### PR DESCRIPTION
This enables us to support both #18 and #19, viz.:

```
nix run .#activate srid@somemachine
```