### PR TITLE
`.#activate` app: Activate home-manager configuration

### DIFF
--- a/activate/activate.nu
+++ b/activate/activate.nu
@@ -62,10 +62,10 @@ def activate_home [ user: string, host: string ] {
 }
 
 def activate_home_local [ user: string, host: string ] {
-    let name = $"#($user)" + (if ($host | is-empty) { "" } else { "@" + $host })
+    let name = $"($user)" + (if ($host | is-empty) { "" } else { "@" + $host })
     log info $"Activating home configuration ($name) (ansi purple)locally(ansi reset)"
-    log info $"(ansi blue_bold)>>>(ansi reset) home-manager switch --flake ($data.cleanFlake)($name)"
-    home-manager switch --flake $"($data.cleanFlake)($name)"
+    log info $"(ansi blue_bold)>>>(ansi reset) home-manager switch --flake ($data.cleanFlake)#($name)"
+    home-manager switch --flake $"($data.cleanFlake)#($name)"
 }
 
 def activate_system [ hostData: record ] {

--- a/activate/activate.nu
+++ b/activate/activate.nu
@@ -54,7 +54,7 @@ def main [
 
 def activate_home [ user: string, host: string ] {
     if ($host | is-empty) {
-        activate_home_local $user $home
+        activate_home_local $user $host
     } else {
         # TODO: allow if host == CURRENT_HOSTNAME
         log error $"Remote activation not yet supported for homeConfigurations"

--- a/activate/activate.nu
+++ b/activate/activate.nu
@@ -65,7 +65,7 @@ def activate_home [ user: string, host: string ] {
 }
 
 def activate_home_local [ user: string, host: string ] {
-    let name = $"#($user)" + (if $host | is-empty { "" } else { "@" + $host })
+    let name = $"#($user)" + (if ($host | is-empty) { "" } else { "@" + $host })
     log info $"Activating home configuration ($name) (ansi purple)locally(ansi reset)"
     log info $"(ansi blue_bold)>>>(ansi reset) home-manager switch --flake ($data.cleanFlake)($name)"
     home-manager switch --flake $"($data.cleanFlake)($name)"

--- a/activate/activate.nu
+++ b/activate/activate.nu
@@ -3,8 +3,6 @@ use std assert
 
 use nixos-flake.nu getData  # This module is generated in Nix
 
-print "OKAY"
-
 let CURRENT_HOSTNAME = (hostname | str trim)
 let data = getData
 
@@ -54,29 +52,24 @@ def main [
     }
 }
 
-# TODO: https://github.com/srid/nixos-flake/issues/18
 def activate_home [ user: string, host: string ] {
-    # log error $"Cannot activate home environments yet; use .#activate-home instead"
-    # exit 1
     if ($host | is-empty) {
-        activate_home_local $user
+        activate_home_local $user $home
     } else {
-        let hostData = get_host_data $host
-        activate_home_remote_ssh $user $hostData
+        # TODO: allow if host == CURRENT_HOSTNAME
+        log error $"Remote activation not yet supported for homeConfigurations"
+        exit 1
+        # let hostData = get_host_data $host
+        # activate_home_remote_ssh $user $hostData
     }
 }
 
-def activate_home_local [ user: string ] {
-    log info $"Activating home configuration (ansi purple)locally(ansi reset)"
-    log info $"(ansi blue_bold)>>>(ansi reset) home-manager switch --dry-run --flake ($data.cleanFlake)#($user)"
-    home-manager switch --dry-run --flake $"($data.cleanFlake)#($user)"
+def activate_home_local [ user: string, host: string ] {
+    let name = $"#($user)" + (if $host | is-empty { "" } else { "@" + $host })
+    log info $"Activating home configuration ($name) (ansi purple)locally(ansi reset)"
+    log info $"(ansi blue_bold)>>>(ansi reset) home-manager switch --flake ($data.cleanFlake)($name)"
+    home-manager switch --flake $"($data.cleanFlake)($name)"
 }
-
-#def activate_home_remote_ssh [ user: string, host: string ] {
-#    log info $"Activating home configuration (ansi purple_reverse)remotely(ansi reset) on ($hostData.sshTarget)"
-#    log info $"(ansi blue_bold)>>>(ansi reset) ssh -t ($hostData.sshTarget) nix --extra-experimental-features '"nix-command flakes"' run ($hostData.outputs.nixArgs | str join) $"($data.cleanFlake)#activate-home ($user)"
-#    ssh -t $hostData.sshTarget nix --extra-experimental-features '"nix-command flakes"' run ...$hostData.outputs.nixArgs $"($data.cleanFlake)#activate ($user)"
-#}
 
 def activate_system [ hostData: record ] {
     log info $"(ansi grey)currentSystem=($data.system) currentHost=(ansi green_bold)($CURRENT_HOSTNAME)(ansi grey) targetHost=(ansi green_reverse)($hostData.host)(ansi reset)(ansi grey) hostData=($hostData)(ansi reset)"

--- a/activate/activate.nu
+++ b/activate/activate.nu
@@ -53,14 +53,11 @@ def main [
 }
 
 def activate_home [ user: string, host: string ] {
-    if ($host | is-empty) {
+    if (($host | is-empty) or ($host == $CURRENT_HOSTNAME)) {
         activate_home_local $user $host
     } else {
-        # TODO: allow if host == CURRENT_HOSTNAME
         log error $"Remote activation not yet supported for homeConfigurations"
         exit 1
-        # let hostData = get_host_data $host
-        # activate_home_remote_ssh $user $hostData
     }
 }
 

--- a/activate/default.nix
+++ b/activate/default.nix
@@ -8,7 +8,7 @@ let
         name = "nixos-flake-activate-flake";
         src = self;
       };
-      nixos-flake-configs = lib.mapAttrs (name: value: value.config.nixos-flake or { }) (self.nixosConfigurations or { } // self.darwinConfigurations or { } // self.legacyPackages.${system}.homeConfigurations);
+      nixos-flake-configs = lib.mapAttrs (name: value: value.config.nixos-flake or { }) (self.nixosConfigurations or { } // self.darwinConfigurations or { });
       data = {
         nixos-flake-configs = nixos-flake-configs;
         system = system;

--- a/activate/default.nix
+++ b/activate/default.nix
@@ -8,7 +8,7 @@ let
         name = "nixos-flake-activate-flake";
         src = self;
       };
-      nixos-flake-configs = lib.mapAttrs (name: value: value.config.nixos-flake or { }) (self.nixosConfigurations or { } // self.darwinConfigurations or { });
+      nixos-flake-configs = lib.mapAttrs (name: value: value.config.nixos-flake) (self.nixosConfigurations or { } // self.darwinConfigurations or { });
       data = {
         nixos-flake-configs = nixos-flake-configs;
         system = system;

--- a/doc/activate.md
+++ b/doc/activate.md
@@ -1,23 +1,49 @@
 
 # Activation
 
-`nixos-flake` provides the `.#activate` flake app that can be used in place of `nixos-rebuild` (if using NixOS) and `darwin-rebuild` (if using `nix-darwin`).
+`nixos-flake` provides an `.#activate` flake app that can be used in place of `nixos-rebuild switch` (if using NixOS),`darwin-rebuild switch` (if using `nix-darwin`) or `home-manager switch` (if using home-manager)
 
-In addition, it can also activate the system over SSH -- see next section.
+In addition, it can also activate the system over SSH (see further below).
+
+{#system}
+## Activating NixOS or nix-darwin configurations
+
+
+In order to activate a system configuration for the current host (`$HOSTNAME`), run:
 
 ```sh
 nix run .#activate
 ```
 
-Usually, you'd make this your default package, so as to be able to use `nix run`. In `flake.nix`:
+>[!TIP] `nix run`
+> Usually, you'd make this your default package, so as to be able to use `nix run`. In `flake.nix`:
+> 
+> ```nix
+> # In perSystem
+> {
+>     packages.default = self'.packages.activate
+> }
+> ```
 
-```nix
-# In perSystem
-{
-    packages.default = self'.packages.activate
-}
+{#home}
+## Activating home configuration
+
+If you are on a non-NixOS Linux (or on macOS but you do not use nix-darwin), you will have a home-manager configuration. Suppose, you have it stored in `legacyPackages.homeConfigurations."myuser"` (where `myuser` matches `$USER`), you can activate that by running:
+
+```sh
+nix run .#activate $USER@
 ```
 
+>[!NOTE] `user@host`
+> The activate app will activate the home-manager configuration if the argument contains a `@` (separating user and the optional hostname). The above command has no hostname, indicating that we are activating for the local host.
+
+### Per-host home configurations
+
+You have host-specific home configurations, such as `legacyPackages.homeConfigurations."myuser@myhost"`, which can be activated using:
+
+```sh
+nix run .#activate $USER@$HOSTNAME
+```
 
 {#remote}
 ## Remote Activation

--- a/doc/activate.md
+++ b/doc/activate.md
@@ -37,6 +37,7 @@ nix run .#activate $USER@
 >[!NOTE] `user@host`
 > The activate app will activate the home-manager configuration if the argument contains a `@` (separating user and the optional hostname). The above command has no hostname, indicating that we are activating for the local host.
 
+{#home-perhost}
 ### Per-host home configurations
 
 You have host-specific home configurations, such as `legacyPackages.homeConfigurations."myuser@myhost"`, which can be activated using:

--- a/doc/module-outputs.md
+++ b/doc/module-outputs.md
@@ -8,8 +8,7 @@ Importing the `nixos-flake` flake-parts module will autowire the following flake
 | **nixosModules.home-manager**  | Home-manager setup module for NixOS            |
 | **darwinModules_.home-manager**[^und] | Home-manager setup module for Darwin           |
 | **packages.update**            | Flake app to update key flake inputs            |
-| [[activate\|packages.activate]]          | Flake app to build & activate the system (locally or remotely over SSH)       |
-| **packages.activate-home**[^home]          | Flake app to build & activate the `homeConfigurations` for current user       |
+| [[activate\|packages.activate]]          | Flake app to build & activate the system (locally or remotely over SSH) or home configuration       |
 
 In addition, all of your NixOS/nix-darwin/home-manager modules implicitly receive the following `specialArgs`:
 

--- a/doc/templates.md
+++ b/doc/templates.md
@@ -43,7 +43,7 @@ nix flake init -t github:srid/nixos-flake#home
 ## After initializing the template
 
 1. open the generated `flake.nix` and change the user (from "john") as well as hostname (from "example1") to match that of your environment (Run `echo $USER` and `hostname -s` to determine the new values).[^intel] 
-2. Then run `nix run .#activate` (`nix run .#activate-home` if you are using the 4th template) to activate the configuration.
+2. Then run `nix run .#activate` (`nix run .#activate $USER` if you are using the 4th template, "Home only") to activate the configuration.
 
 [^intel]: If you are on an Intel Mac, change `mkARMMacosSystem` to `mkIntelMacosSystem`.
 

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -99,6 +99,9 @@ in
           })
         ];
       };
+
+      homeModules.nixosFlake = ./nixos-module.nix;
+
       nixos-flake.lib = rec {
         inherit specialArgsFor;
 
@@ -122,7 +125,11 @@ in
         mkHomeConfiguration = pkgs: mod: inputs.home-manager.lib.homeManagerConfiguration {
           inherit pkgs;
           extraSpecialArgs = specialArgsFor.common;
-          modules = [ mod ];
+          modules = [
+            # FIXME: Getting `error: infinite recursion encountered` on `id = x: x`
+            # self.homeModules.nixosFlake
+            mod
+          ];
         };
       };
     };

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -100,8 +100,6 @@ in
         ];
       };
 
-      homeModules.nixosFlake = ./nixos-module.nix;
-
       nixos-flake.lib = rec {
         inherit specialArgsFor;
 
@@ -125,11 +123,7 @@ in
         mkHomeConfiguration = pkgs: mod: inputs.home-manager.lib.homeManagerConfiguration {
           inherit pkgs;
           extraSpecialArgs = specialArgsFor.common;
-          modules = [
-            # FIXME: Getting `error: infinite recursion encountered` on `id = x: x`
-            # self.homeModules.nixosFlake
-            mod
-          ];
+          modules = [ mod ];
         };
       };
     };

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -47,24 +47,8 @@ in
                 '';
               };
 
-            # New-style activate app that can also activate remotely over SSH.
+            # Activate the given (system or home) configuration
             activate = import ../activate { inherit self inputs' pkgs lib system; };
-
-            activate-home =
-              if hasNonEmptyAttr [ "homeConfigurations" ] self || hasNonEmptyAttr [ "legacyPackages" system "homeConfigurations" ] self
-              then
-                pkgs.writeShellApplication
-                  {
-                    name = "activate-home";
-                    text =
-                      ''
-                        set -x
-                        nix run \
-                          .#homeConfigurations."\"''${USER}\"".activationPackage \
-                          "$@"
-                      '';
-                  }
-              else null;
           };
         };
       });

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -99,7 +99,6 @@ in
           })
         ];
       };
-
       nixos-flake.lib = rec {
         inherit specialArgsFor;
 

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -1,3 +1,5 @@
+# FIXME: Using this module in home-manager leads to `error: infinite recursion
+# encountered` on `id = x: x`
 { flake, config, lib, ... }: {
   options = {
     nixos-flake.sshTarget = lib.mkOption {


### PR DESCRIPTION
Resolves #18 and resolves #19

- [x] Proof of concept https://github.com/srid/nixos-config/pull/61
- [ ] Can we (_should_ we?) have `nix run .` automatically activate the home config rather than system config? 
    - cf. https://github.com/juspay/nix-dev-home/blob/56b2fcac1f425b0a7c5dd84b1b8e071add258cfb/nix/toplevel.nix#L29-L30
- [x] Remove `.#activate-home`; adjust Templates & Docs

<img width="910" alt="image" src="https://github.com/srid/nixos-flake/assets/3998/29a15060-60b8-4fcd-8dcb-4da9da118635">
