### PR TITLE
Don't output `nixosModules` / `darwinModules`

### DIFF
--- a/doc/module-outputs.md
+++ b/doc/module-outputs.md
@@ -5,8 +5,6 @@ Importing the `nixos-flake` flake-parts module will autowire the following flake
 | Name                         | Description                                    |
 | ---------------------------- | ---------------------------------------------- |
 | **nixos-flake.lib**             | Functions `mkLinuxSystem`, `mkMacosSystem` and `mkHomeConfiguration` |
-| **nixosModules.home-manager**  | Home-manager setup module for NixOS            |
-| **darwinModules_.home-manager**[^und] | Home-manager setup module for Darwin           |
 | **packages.update**            | Flake app to update key flake inputs            |
 | [[activate\|packages.activate]]          | Flake app to build & activate the system (locally or remotely over SSH) or home configuration       |
 

--- a/examples/linux/flake.nix
+++ b/examples/linux/flake.nix
@@ -20,27 +20,29 @@
         in
         {
           # Configurations for Linux (NixOS) machines
-          nixosConfigurations."example1" = self.nixos-flake.lib.mkLinuxSystem {
-            nixpkgs.hostPlatform = "x86_64-linux";
-            imports = [
-              # Your machine's configuration.nix goes here
-              ({ pkgs, ... }: {
-                # TODO: Put your /etc/nixos/hardware-configuration.nix here
-                boot.loader.grub.device = "nodev";
-                fileSystems."/" = { device = "/dev/disk/by-label/nixos"; fsType = "btrfs"; };
-                users.users.${myUserName}.isNormalUser = true;
-                system.stateVersion = "23.05";
-              })
-              # Setup home-manager in NixOS config
-              self.nixosModules.home-manager
+          nixosConfigurations."example1" =
+            self.nixos-flake.lib.mkLinuxSystem
+              { home-manager = true; }
               {
-                home-manager.users.${myUserName} = {
-                  imports = [ self.homeModules.default ];
-                  home.stateVersion = "22.11";
-                };
-              }
-            ];
-          };
+                nixpkgs.hostPlatform = "x86_64-linux";
+                imports = [
+                  # Your machine's configuration.nix goes here
+                  ({ pkgs, ... }: {
+                    # TODO: Put your /etc/nixos/hardware-configuration.nix here
+                    boot.loader.grub.device = "nodev";
+                    fileSystems."/" = { device = "/dev/disk/by-label/nixos"; fsType = "btrfs"; };
+                    users.users.${myUserName}.isNormalUser = true;
+                    system.stateVersion = "23.05";
+                  })
+                  # Setup home-manager in NixOS config
+                  {
+                    home-manager.users.${myUserName} = {
+                      imports = [ self.homeModules.default ];
+                      home.stateVersion = "22.11";
+                    };
+                  }
+                ];
+              };
 
           # home-manager configuration goes here.
           homeModules.default = { pkgs, ... }: {

--- a/examples/macos/flake.nix
+++ b/examples/macos/flake.nix
@@ -25,7 +25,6 @@
           darwinConfigurations."example1" = self.nixos-flake.lib.mkMacosSystem {
             nixpkgs.hostPlatform = "aarch64-darwin";
             imports = [
-              self.darwinModules_.nix-darwin
               # Your nix-darwin configuration goes here
               ({ pkgs, ... }: {
                 # https://github.com/nix-community/home-manager/issues/4026#issuecomment-1565487545

--- a/examples/macos/flake.nix
+++ b/examples/macos/flake.nix
@@ -22,30 +22,32 @@
         in
         {
           # Configurations for macOS machines
-          darwinConfigurations."example1" = self.nixos-flake.lib.mkMacosSystem {
-            nixpkgs.hostPlatform = "aarch64-darwin";
-            imports = [
-              # Your nix-darwin configuration goes here
-              ({ pkgs, ... }: {
-                # https://github.com/nix-community/home-manager/issues/4026#issuecomment-1565487545
-                users.users.${myUserName}.home = "/Users/${myUserName}";
-
-                security.pam.enableSudoTouchIdAuth = true;
-
-                # Used for backwards compatibility, please read the changelog before changing.
-                # $ darwin-rebuild changelog
-                system.stateVersion = 4;
-              })
-              # Setup home-manager in nix-darwin config
-              self.darwinModules_.home-manager
+          darwinConfigurations."example1" =
+            self.nixos-flake.lib.mkMacosSystem
+              { home-manager = true; }
               {
-                home-manager.users.${myUserName} = {
-                  imports = [ self.homeModules.default ];
-                  home.stateVersion = "22.11";
-                };
-              }
-            ];
-          };
+                nixpkgs.hostPlatform = "aarch64-darwin";
+                imports = [
+                  # Your nix-darwin configuration goes here
+                  ({ pkgs, ... }: {
+                    # https://github.com/nix-community/home-manager/issues/4026#issuecomment-1565487545
+                    users.users.${myUserName}.home = "/Users/${myUserName}";
+
+                    security.pam.enableSudoTouchIdAuth = true;
+
+                    # Used for backwards compatibility, please read the changelog before changing.
+                    # $ darwin-rebuild changelog
+                    system.stateVersion = 4;
+                  })
+                  # Setup home-manager in nix-darwin config
+                  {
+                    home-manager.users.${myUserName} = {
+                      imports = [ self.homeModules.default ];
+                      home.stateVersion = "22.11";
+                    };
+                  }
+                ];
+              };
 
           # home-manager configuration goes here.
           homeModules.default = { pkgs, ... }: {

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -16,51 +16,51 @@ let
   hasNonEmptyAttr = attrPath: self:
     lib.attrByPath attrPath { } self != { };
 
-    nixosModules = {
-      # Linux home-manager module
-      home-manager = {
-        imports = [
-          inputs.home-manager.nixosModules.home-manager
-          ({
-            home-manager.useGlobalPkgs = true;
-            home-manager.useUserPackages = true;
-            home-manager.extraSpecialArgs = specialArgsFor.nixos;
-          })
-        ];
-      };
+  nixosModules = {
+    # Linux home-manager module
+    home-manager = {
+      imports = [
+        inputs.home-manager.nixosModules.home-manager
+        ({
+          home-manager.useGlobalPkgs = true;
+          home-manager.useUserPackages = true;
+          home-manager.extraSpecialArgs = specialArgsFor.nixos;
+        })
+      ];
     };
+  };
 
-    darwinModules = {
-      # macOS home-manager module
-      home-manager = {
-        imports = [
-          inputs.home-manager.darwinModules.home-manager
-          ({
-            home-manager.useGlobalPkgs = true;
-            home-manager.useUserPackages = true;
-            home-manager.extraSpecialArgs = specialArgsFor.darwin;
-            home-manager.sharedModules = [{
-              home.sessionPath = [
-                "/etc/profiles/per-user/$USER/bin" # To access home-manager binaries
-                "/nix/var/nix/profiles/system/sw/bin" # To access nix-darwin binaries
-                "/usr/local/bin" # Some macOS GUI programs install here
-              ];
-            }];
-          })
-        ];
-      };
-      # nix-darwin module containing necessary configuration
-      # Required when using the DetSys installer
-      # cf. https://github.com/srid/nixos-flake/issues/52
-      nix-darwin = {
-        nix = {
-          useDaemon = true; # Required on multi-user Nix install
-          settings = {
-            experimental-features = "nix-command flakes"; # Enable flakes
-          };
+  darwinModules = {
+    # macOS home-manager module
+    home-manager = {
+      imports = [
+        inputs.home-manager.darwinModules.home-manager
+        ({
+          home-manager.useGlobalPkgs = true;
+          home-manager.useUserPackages = true;
+          home-manager.extraSpecialArgs = specialArgsFor.darwin;
+          home-manager.sharedModules = [{
+            home.sessionPath = [
+              "/etc/profiles/per-user/$USER/bin" # To access home-manager binaries
+              "/nix/var/nix/profiles/system/sw/bin" # To access nix-darwin binaries
+              "/usr/local/bin" # Some macOS GUI programs install here
+            ];
+          }];
+        })
+      ];
+    };
+    # nix-darwin module containing necessary configuration
+    # Required when using the DetSys installer
+    # cf. https://github.com/srid/nixos-flake/issues/52
+    nix-darwin = {
+      nix = {
+        useDaemon = true; # Required on multi-user Nix install
+        settings = {
+          experimental-features = "nix-command flakes"; # Enable flakes
         };
       };
     };
+  };
 in
 {
   options = {

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -15,6 +15,52 @@ let
   };
   hasNonEmptyAttr = attrPath: self:
     lib.attrByPath attrPath { } self != { };
+
+    nixosModules = {
+      # Linux home-manager module
+      home-manager = {
+        imports = [
+          inputs.home-manager.nixosModules.home-manager
+          ({
+            home-manager.useGlobalPkgs = true;
+            home-manager.useUserPackages = true;
+            home-manager.extraSpecialArgs = specialArgsFor.nixos;
+          })
+        ];
+      };
+    };
+
+    darwinModules = {
+      # macOS home-manager module
+      home-manager = {
+        imports = [
+          inputs.home-manager.darwinModules.home-manager
+          ({
+            home-manager.useGlobalPkgs = true;
+            home-manager.useUserPackages = true;
+            home-manager.extraSpecialArgs = specialArgsFor.darwin;
+            home-manager.sharedModules = [{
+              home.sessionPath = [
+                "/etc/profiles/per-user/$USER/bin" # To access home-manager binaries
+                "/nix/var/nix/profiles/system/sw/bin" # To access nix-darwin binaries
+                "/usr/local/bin" # Some macOS GUI programs install here
+              ];
+            }];
+          })
+        ];
+      };
+      # nix-darwin module containing necessary configuration
+      # Required when using the DetSys installer
+      # cf. https://github.com/srid/nixos-flake/issues/52
+      nix-darwin = {
+        nix = {
+          useDaemon = true; # Required on multi-user Nix install
+          settings = {
+            experimental-features = "nix-command flakes"; # Enable flakes
+          };
+        };
+      };
+    };
 in
 {
   options = {
@@ -57,74 +103,25 @@ in
 
   config = {
     flake = {
-      nixosModules = {
-        nixosFlake = ./nixos-module.nix;
-        # Linux home-manager module
-        home-manager = {
-          imports = [
-            inputs.home-manager.nixosModules.home-manager
-            ({
-              home-manager.useGlobalPkgs = true;
-              home-manager.useUserPackages = true;
-              home-manager.extraSpecialArgs = specialArgsFor.nixos;
-            })
-          ];
-        };
-      };
-
-      # This is named with an underscope, because flake-parts segfaults otherwise!
-      # See https://github.com/srid/nixos-config/issues/31
-      darwinModules_ = {
-        nixosFlake = ./nixos-module.nix;
-        # macOS home-manager module
-        home-manager = {
-          imports = [
-            inputs.home-manager.darwinModules.home-manager
-            ({
-              home-manager.useGlobalPkgs = true;
-              home-manager.useUserPackages = true;
-              home-manager.extraSpecialArgs = specialArgsFor.darwin;
-              home-manager.sharedModules = [{
-                home.sessionPath = [
-                  "/etc/profiles/per-user/$USER/bin" # To access home-manager binaries
-                  "/nix/var/nix/profiles/system/sw/bin" # To access nix-darwin binaries
-                  "/usr/local/bin" # Some macOS GUI programs install here
-                ];
-              }];
-            })
-          ];
-        };
-        # nix-darwin module containing necessary configuration
-        # Required when using the DetSys installer
-        # cf. https://github.com/srid/nixos-flake/issues/52
-        nix-darwin = {
-          nix = {
-            useDaemon = true; # Required on multi-user Nix install
-            settings = {
-              experimental-features = "nix-command flakes"; # Enable flakes
-            };
-          };
-        };
-      };
-
       nixos-flake.lib = rec {
         inherit specialArgsFor;
 
-        mkLinuxSystem = mod: inputs.nixpkgs.lib.nixosSystem {
+        mkLinuxSystem = { home-manager ? false }: mod: inputs.nixpkgs.lib.nixosSystem {
           # Arguments to pass to all modules.
           specialArgs = specialArgsFor.nixos;
           modules = [
-            self.nixosModules.nixosFlake
+            ./nixos-module.nix
             mod
-          ];
+          ] ++ lib.optional home-manager nixosModules.home-manager;
         };
 
-        mkMacosSystem = mod: inputs.nix-darwin.lib.darwinSystem {
+        mkMacosSystem = { home-manager ? false }: mod: inputs.nix-darwin.lib.darwinSystem {
           specialArgs = specialArgsFor.darwin;
           modules = [
-            self.darwinModules_.nixosFlake
+            ./nixos-module.nix
+            darwinModules.nix-darwin
             mod
-          ];
+          ] ++ lib.optional home-manager darwinModules.home-manager;
         };
 
         mkHomeConfiguration = pkgs: mod: inputs.home-manager.lib.homeManagerConfiguration {


### PR DESCRIPTION
This is mainly to sidestep the segfault with flake-parts. Also, `mk*System` functions now take a flag for automatically including home-manager support.