### PR TITLE
Autowire based on directory structure

### DIFF
--- a/examples/home/flake.nix
+++ b/examples/home/flake.nix
@@ -13,7 +13,7 @@
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
       systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
       imports = [
-        inputs.nixos-flake.flakeModule
+        inputs.nixos-flake.flakeModules.default
       ];
 
       perSystem = { pkgs, ... }:

--- a/examples/linux/flake.nix
+++ b/examples/linux/flake.nix
@@ -12,7 +12,7 @@
   outputs = inputs@{ self, ... }:
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
       systems = [ "x86_64-linux" "aarch64-linux" ];
-      imports = [ inputs.nixos-flake.flakeModule ];
+      imports = [ inputs.nixos-flake.flakeModules.default ];
 
       flake =
         let

--- a/examples/macos/flake.nix
+++ b/examples/macos/flake.nix
@@ -14,7 +14,7 @@
   outputs = inputs@{ self, ... }:
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
       systems = [ "aarch64-darwin" "x86_64-darwin" ];
-      imports = [ inputs.nixos-flake.flakeModule ];
+      imports = [ inputs.nixos-flake.flakeModules.default ];
 
       flake =
         let

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,11 @@
 {
   outputs = _: rec {
-    flakeModule = ./nix/modules/flake-parts;
+    flakeModules = {
+     default =  ./nix/modules/flake-parts;
+     autoWire = ./nix/modules/flake-parts/autowire.nix;
+    };
+    # For backwards compat only
+    flakeModule = flakeModules.default;
 
     templates =
       let

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,8 @@
 {
   outputs = _: rec {
     flakeModules = {
-     default =  ./nix/modules/flake-parts;
-     autoWire = ./nix/modules/flake-parts/autowire.nix;
+      default = ./nix/modules/flake-parts;
+      autoWire = ./nix/modules/flake-parts/autowire.nix;
     };
     # For backwards compat only
     flakeModule = flakeModules.default;

--- a/nix/modules/flake-parts/autowire.nix
+++ b/nix/modules/flake-parts/autowire.nix
@@ -1,0 +1,51 @@
+{ self, lib, ... }:
+let
+in
+{
+  config =
+    let
+      forAllNixFiles = dir: f:
+        if builtins.pathExists dir then
+          lib.pipe dir [
+            builtins.readDir
+            (lib.filterAttrs (_: type: type == "regular"))
+            (lib.mapAttrs' (fn: _:
+              let name = lib.removeSuffix ".nix" fn; in
+              lib.nameValuePair name (f "${dir}/${fn}")
+            ))
+          ] else { };
+    in
+    {
+      flake = {
+        darwinConfigurations =
+          forAllNixFiles "${self}/configurations/darwin"
+            (fn: self.nixos-flake.lib.mkMacosSystem { home-manager = true; } fn);
+
+        nixosConfigurations =
+          forAllNixFiles "${self}/configurations/nixos"
+            (fn: self.nixos-flake.lib.mkLinuxSystem { home-manager = true; } fn);
+
+        darwinModules =
+          forAllNixFiles "${self}/modules/darwin"
+            (fn: fn);
+
+        nixosModules =
+          forAllNixFiles "${self}/modules/nixos"
+            (fn: fn);
+
+        homeModules =
+          forAllNixFiles "${self}/modules/home"
+            (fn: fn);
+
+        overlays =
+          forAllNixFiles "${self}/overlays"
+            (fn: import fn self.nixos-flake.lib.specialArgsFor.common);
+      };
+
+      perSystem = { pkgs, ... }: {
+        legacyPackages.homeConfigurations =
+          forAllNixFiles "${self}/configurations/home"
+            (fn: self.nixos-flake.lib.mkHomeConfiguration pkgs fn);
+      };
+    };
+}


### PR DESCRIPTION
Upstreaming https://x.com/sridca/status/1840148796317040945 to `nixos-flake`

The idea is to automatically create `nixosConfigurations`, `darwinConfigurations`, `homeConfigurations`, `nixosModules`, `darwinModules`, `homeModules`, and `overlays` based on the files positioned at particular directory structure (see the linked X post).

- [x] Initial prototype
- [ ] Allow disabling this behaviour (leaving it off by default)
- [ ] Docs