### PR TITLE
Add common settings to all configurations

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -15,15 +15,18 @@ emanote:
 
 nixos-flake provides the following features:
 
-- [[activate]]: An `.#activate` flake app that works both on macOS and NixOS.
-  - `.#activate` can also *remotely* activate machines (be it macOS or NixOS) over SSH.
-- All NixOS/ nix-darwin/ home-manager modules receive `specialArgs` which includes all the information in the top-level flake.
-  - This enables those modules to be aware of the flake inputs, for instance.
-- A `.#update` flake app to update the primary inputs (which can be overriden)
+- **One-click activation & deployment**
+  - [[activate]]: An `.#activate` flake app that works both on macOS and NixOS.
+    - `.#activate` can also *remotely* activate machines (be it macOS or NixOS) over SSH, thus acting as a simple alternative to deployment tools like `deploy-rs` and `colmena`.
+  - Also: an `.#update` flake app to update the primary inputs (which can be overriden)
+- **Seamless access to top-level flake**
+  - All NixOS/ nix-darwin/ home-manager modules receive `specialArgs` which includes all the information in the top-level flake.
+    - This enables those modules to be aware of the flake inputs, for instance.
+- **Sensible defaults**
+  - Sensible defaults for home-manager/ nix-darwin/ and NixOS configurations ([\#75](https://github.com/srid/nixos-flake/pull/75)).
 
 ## Getting Started
 
 See: [[start]]# and [[guide]]#. For examples, see [[examples]]#
 
 [home-manager]: https://github.com/nix-community/home-manager
-

--- a/nix/modules/flake-parts/lib.nix
+++ b/nix/modules/flake-parts/lib.nix
@@ -73,6 +73,8 @@ in
       nixos-flake.lib = {
         inherit specialArgsFor;
 
+        inherit nixosModules darwinModules homeModules;
+
         mkLinuxSystem = { home-manager ? false }: mod: inputs.nixpkgs.lib.nixosSystem {
           # Arguments to pass to all modules.
           specialArgs = specialArgsFor.nixos;

--- a/nix/modules/flake-parts/lib.nix
+++ b/nix/modules/flake-parts/lib.nix
@@ -24,20 +24,13 @@ let
     };
 
     # Common and useful setting across all platforms
-    common = { flake, lib, ... }: {
+    common = { lib, ... }: {
       nix = {
-        # Enables use of `nix-shell -p ...` etc
-        nixPath = [ "nixpkgs=${flake.inputs.nixpkgs}" ];
-        # Make `nix shell` etc use pinned nixpkgs
-        registry.nixpkgs.flake = flake.inputs.nixpkgs;
-
         settings = {
           # Use all CPU cores
           max-jobs = lib.mkDefault "auto";
           # Duh
           experimental-features = lib.mkDefault "nix-command flakes";
-          # Nullify the registry for purity.
-          flake-registry = builtins.toFile "empty-flake-registry.json" ''{"flakes":[],"version":2}'';
         };
       };
     };

--- a/nix/modules/flake-parts/lib.nix
+++ b/nix/modules/flake-parts/lib.nix
@@ -59,12 +59,7 @@ let
     # Required when using the DetSys installer
     # cf. https://github.com/srid/nixos-flake/issues/52
     nix-darwin = {
-      nix = {
-        useDaemon = true; # Required on multi-user Nix install
-        settings = {
-          experimental-features = "nix-command flakes"; # Enable flakes
-        };
-      };
+      nix.useDaemon = true; # Required on multi-user Nix install
     };
   };
 in

--- a/nix/modules/flake-parts/lib.nix
+++ b/nix/modules/flake-parts/lib.nix
@@ -73,8 +73,6 @@ in
       nixos-flake.lib = {
         inherit specialArgsFor;
 
-        inherit nixosModules darwinModules homeModules;
-
         mkLinuxSystem = { home-manager ? false }: mod: inputs.nixpkgs.lib.nixosSystem {
           # Arguments to pass to all modules.
           specialArgs = specialArgsFor.nixos;
@@ -98,7 +96,10 @@ in
         mkHomeConfiguration = pkgs: mod: inputs.home-manager.lib.homeManagerConfiguration {
           inherit pkgs;
           extraSpecialArgs = specialArgsFor.common;
-          modules = [ mod ];
+          modules = [
+            homeModules.common
+            mod
+          ];
         };
       };
     };

--- a/nix/modules/flake-parts/lib.nix
+++ b/nix/modules/flake-parts/lib.nix
@@ -22,6 +22,25 @@ let
         }
       ];
     };
+
+    # Common and useful setting across all platforms
+    common = { flake, lib, ... }: {
+      nix = {
+        # Enables use of `nix-shell -p ...` etc
+        nixPath = [ "nixpkgs=${flake.inputs.nixpkgs}" ];
+        # Make `nix shell` etc use pinned nixpkgs
+        registry.nixpkgs.flake = flake.inputs.nixpkgs;
+
+        settings = {
+          # Use all CPU cores
+          max-jobs = lib.mkDefault "auto";
+          # Duh
+          experimental-features = lib.mkDefault "nix-command flakes";
+          # Nullify the registry for purity.
+          flake-registry = builtins.toFile "empty-flake-registry.json" ''{"flakes":[],"version":2}'';
+        };
+      };
+    };
   };
 
   darwinModules = {
@@ -67,6 +86,7 @@ in
           specialArgs = specialArgsFor.nixos;
           modules = [
             ../configurations
+            nixosModules.common
             mod
           ] ++ lib.optional home-manager nixosModules.home-manager;
         };
@@ -75,6 +95,7 @@ in
           specialArgs = specialArgsFor.darwin;
           modules = [
             ../configurations
+            nixosModules.common
             darwinModules.nix-darwin
             mod
           ] ++ lib.optional home-manager darwinModules.home-manager;

--- a/nix/modules/flake-parts/lib.nix
+++ b/nix/modules/flake-parts/lib.nix
@@ -36,6 +36,16 @@ let
     };
   };
 
+  homeModules = {
+    common = { pkgs, ... }: {
+      home.sessionPath = lib.mkIf pkgs.stdenv.isDarwin [
+        "/etc/profiles/per-user/$USER/bin" # To access home-manager binaries
+        "/nix/var/nix/profiles/system/sw/bin" # To access nix-darwin binaries
+        "/usr/local/bin" # Some macOS GUI programs install here
+      ];
+    };
+  };
+
   darwinModules = {
     # macOS home-manager module
     home-manager = {
@@ -45,13 +55,7 @@ let
           home-manager.useGlobalPkgs = true;
           home-manager.useUserPackages = true;
           home-manager.extraSpecialArgs = specialArgsFor.darwin;
-          home-manager.sharedModules = [{
-            home.sessionPath = [
-              "/etc/profiles/per-user/$USER/bin" # To access home-manager binaries
-              "/nix/var/nix/profiles/system/sw/bin" # To access nix-darwin binaries
-              "/usr/local/bin" # Some macOS GUI programs install here
-            ];
-          }];
+          home-manager.sharedModules = [ homeModules.common ];
         }
       ];
     };


### PR DESCRIPTION
These are sensible defaults we generally want across all configurations -- home-manager, NixOS, nix-darwin.

Note: NixOS (and nix-darwin) recently gained some defaults that we don't add here: https://github.com/NixOS/nixpkgs/pull/254405