### PR TITLE
SSH-based activation of home-manager config

### DIFF
--- a/activate/activate.nu
+++ b/activate/activate.nu
@@ -60,7 +60,7 @@ def activate_home [ user: string, host: string, --dry-run ] {
 }
 
 def activate_home_local [ user: string, host: string, --dry-run ] {
-    let name = $"($user)" + (if ($host | is-empty) { "" } else { "@" + $host })
+    let name = $"($user)@($host)"
     let extraArgs = if $dry_run { ["--dry-run"] } else { [] }
     log info $"Activating home configuration ($name) (ansi purple)locally(ansi reset)"
     log info $"(ansi blue_bold)>>>(ansi reset) home-manager switch ($extraArgs | str join) --flake ($data.cleanFlake)#($name)"
@@ -68,7 +68,7 @@ def activate_home_local [ user: string, host: string, --dry-run ] {
 }
 
 def activate_home_remote_ssh [ user: string, host: string, --dry-run ] {
-    let name = $"($user)" + (if ($host | is-empty) { "" } else { "@" + $host })
+    let name = $"($user)@($host)"
     let sshTarget = $"($user)@($host)"
     log info $"Activating home configuration ($name) (ansi purple_reverse)remotely(ansi reset) on ($sshTarget)"
 

--- a/activate/activate.nu
+++ b/activate/activate.nu
@@ -55,8 +55,7 @@ def activate_home [ user: string, host: string, --dry-run ] {
     if (($host | is-empty) or ($host == $CURRENT_HOSTNAME)) {
         activate_home_local $user $host --dry-run=$dry_run
     } else {
-        log error $"Remote activation not yet supported for homeConfigurations"
-        exit 1
+        activate_home_remote_ssh $user $host --dry-run=$dry_run
     }
 }
 
@@ -66,6 +65,22 @@ def activate_home_local [ user: string, host: string, --dry-run ] {
     log info $"Activating home configuration ($name) (ansi purple)locally(ansi reset)"
     log info $"(ansi blue_bold)>>>(ansi reset) home-manager switch ($extraArgs | str join) --flake ($data.cleanFlake)#($name)"
     home-manager switch ...$extraArgs -b (date now | format date "nixos-unified.%Y-%m-%d-%H:%M:%S.bak") --flake $"($data.cleanFlake)#($name)"
+}
+
+def activate_home_remote_ssh [ user: string, host: string, --dry-run ] {
+    let name = $"($user)" + (if ($host | is-empty) { "" } else { "@" + $host })
+    let sshTarget = $"($user)@($host)"
+    log info $"Activating home configuration ($name) (ansi purple_reverse)remotely(ansi reset) on ($sshTarget)"
+
+    # Copy the flake and the necessary inputs to the remote host.
+    nix_copy $data.cleanFlake $"ssh-ng://($sshTarget)"
+    $data.nixos-unified-configs | get $host | get outputs.overrideInputs | transpose key value | each { |input|
+        nix_copy $input.value $"ssh-ng://($sshTarget)"
+    }
+
+    # We re-run this activation script, but on the remote host (where it will invoke activate_home_local).
+    log info $'(ansi blue_bold)>>>(ansi reset) ssh -t ($sshTarget) nix --extra-experimental-features '"nix-command flakes"' run $"($data.cleanFlake)#activate" -- ($name) --dry-run=($dry_run)'
+    ssh -t $sshTarget nix --extra-experimental-features '"nix-command flakes"' run $"($data.cleanFlake)#activate" -- ($name) --dry-run=($dry_run)
 }
 
 def activate_system [ hostData: record, --dry-run=false ] {

--- a/activate/activate.nu
+++ b/activate/activate.nu
@@ -72,11 +72,8 @@ def activate_home_remote_ssh [ user: string, host: string, --dry-run ] {
     let sshTarget = $"($user)@($host)"
     log info $"Activating home configuration ($name) (ansi purple_reverse)remotely(ansi reset) on ($sshTarget)"
 
-    # Copy the flake and the necessary inputs to the remote host.
+    # Copy the flake to the remote host.
     nix_copy $data.cleanFlake $"ssh-ng://($sshTarget)"
-    $data.nixos-unified-configs | get $host | get outputs.overrideInputs | transpose key value | each { |input|
-        nix_copy $input.value $"ssh-ng://($sshTarget)"
-    }
 
     # We re-run this activation script, but on the remote host (where it will invoke activate_home_local).
     log info $'(ansi blue_bold)>>>(ansi reset) ssh -t ($sshTarget) nix --extra-experimental-features '"nix-command flakes"' run $"($data.cleanFlake)#activate" -- ($name) --dry-run=($dry_run)'

--- a/dev/flake.lock
+++ b/dev/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1726153070,
-        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
+        "lastModified": 1756770412,
+        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
+        "rev": "4524271976b625a4a605beefd893f270620fd751",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixos-unified": {
       "locked": {
-        "lastModified": 1726266595,
-        "narHash": "sha256-r+mX2ZC/mQ7zlLPeF/HvLNN4VnXfoWxbc5StpKHKDHM=",
+        "lastModified": 1754753812,
+        "narHash": "sha256-sYZLY+hsaMzz3gsYdwHA7conki3H8zSl43YH2xWnKBc=",
         "owner": "srid",
         "repo": "nixos-unified",
-        "rev": "ef4921f6af505ee41ccab57b65b99be9cef63886",
+        "rev": "4a5e3c33c6177237a27902d3fa4d845448d48e2b",
         "type": "github"
       },
       "original": {
@@ -50,11 +50,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727089097,
-        "narHash": "sha256-ZMHMThPsthhUREwDebXw7GX45bJnBCVbfnH1g5iuSPc=",
+        "lastModified": 1758446476,
+        "narHash": "sha256-5rdAi7CTvM/kSs6fHe1bREIva5W3TbImsto+dxG4mBo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "568bfef547c14ca438c56a0bece08b8bb2b71a9c",
+        "rev": "a1f79a1770d05af18111fbbe2a3ab2c42c0f6cd0",
         "type": "github"
       },
       "original": {
@@ -66,23 +66,26 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1725233747,
-        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "lastModified": 1754788789,
+        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1726481836,
-        "narHash": "sha256-MWTBH4dd5zIz2iatDb8IkqSjIeFum9jAqkFxgHLdzO4=",
+        "lastModified": 1754340878,
+        "narHash": "sha256-lgmUyVQL9tSnvvIvBp7x1euhkkCho7n3TMzgjdvgPoU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "20f9370d5f588fb8c72e844c54511cab054b5f40",
+        "rev": "cab778239e705082fe97bb4990e0d24c50924c04",
         "type": "github"
       },
       "original": {
@@ -106,11 +109,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1727098951,
-        "narHash": "sha256-gplorAc0ISAUPemUNOnRUs7jr3WiLiHZb3DJh++IkZs=",
+        "lastModified": 1758206697,
+        "narHash": "sha256-/DbPkh6PZOgfueCbs3uzlk4ASU2nPPsiVWhpMCNkAd0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "35dfece10c642eb52928a48bee7ac06a59f93e9a",
+        "rev": "128222dc911b8e2e18939537bed1762b7f3a04aa",
         "type": "github"
       },
       "original": {

--- a/doc/guide/activate.md
+++ b/doc/guide/activate.md
@@ -50,6 +50,8 @@ You may also have separate home configurations for each machine, such as `legacy
 nix run .#activate $USER@$HOSTNAME
 ```
 
+This will activate the home-manager configuration for the specified host over SSH (see below).
+
 ## Remote Activation {#remote}
 
 `nixos-unified` acts as a lightweight alternative to the various deployment tools such as `deploy-rs` and `colmena`. The `.#activate` app takes the hostname as an argument and supports remote activation for both system configurations (NixOS/nix-darwin) and home-manager configurations.

--- a/doc/guide/activate.md
+++ b/doc/guide/activate.md
@@ -52,9 +52,11 @@ nix run .#activate $USER@$HOSTNAME
 
 ## Remote Activation {#remote}
 
-`nixos-unified` acts as a lightweight alternative to the various deployment tools such as `deploy-rs` and `colmena`. The `.#activate` app takes the hostname as an argument. If you set the `nixos-unified.sshTarget` option in your NixOS or nix-darwin configuration, it will run activation over the SSH connection.
+`nixos-unified` acts as a lightweight alternative to the various deployment tools such as `deploy-rs` and `colmena`. The `.#activate` app takes the hostname as an argument and supports remote activation for both system configurations (NixOS/nix-darwin) and home-manager configurations.
 
-Add the following to your configuration -- `nixosConfigurations.myhost` or `darwinConfigurations.myhost` (depending on the platform):
+### Remote System Activation {#remote-system}
+
+For NixOS or nix-darwin configurations, set the `nixos-unified.sshTarget` option in your configuration:
 
 ```nix
 {
@@ -67,6 +69,21 @@ Then, you will be able to run the following to deploy to `myhost` from any machi
 ```sh
 nix run .#activate myhost
 ```
+
+### Remote Home-Manager Activation {#remote-home}
+
+For home-manager configurations, remote activation works by specifying the user and hostname:
+
+```sh
+nix run .#activate myuser@myhost
+```
+
+This will:
+1. Copy the flake and necessary inputs to the remote host via SSH
+2. Run the home-manager activation remotely on the target machine
+
+> [!NOTE]
+> Remote home-manager activation uses the `user@host` format for the SSH connection, where the user is extracted from the configuration name and the host is the target machine.
 
 ### Non-goals
 

--- a/doc/history.md
+++ b/doc/history.md
@@ -9,7 +9,7 @@ order: 100
 - autoWiring of flake outputs & `mkFlake`
 - activate script
   - add `--dry-run` (#104)
-  - Remote activation support for home-manager configurations (??)
+  - Remote activation support for home-manager configurations (#143)
 - home-manager
   - More unique backup filenames (#97)
   - Add a default `home.homeDirectory` based on the user's username (#117)

--- a/doc/history.md
+++ b/doc/history.md
@@ -7,7 +7,9 @@ order: 100
 ## Unreleased
 
 - autoWiring of flake outputs & `mkFlake`
-- activate script: add `--dry-run` (#104)
+- activate script
+  - add `--dry-run` (#104)
+  - Remote activation support for home-manager configurations (??)
 - home-manager
   - More unique backup filenames (#97)
   - Add a default `home.homeDirectory` based on the user's username (#117)

--- a/vira.hs
+++ b/vira.hs
@@ -1,0 +1,7 @@
+-- CI configuration <https://vira.nixos.asia/>
+\ctx pipeline ->
+  let isMaster = ctx.branch == "master"
+  in pipeline
+    { signoff.enable = True
+    , attic.enable = isMaster
+    }


### PR DESCRIPTION
[Remote Activation](https://nixos-unified.org/guide/activate#remote) so far supported activating NixOS and nix-darwin configurations over SSH. This PR enables the same for activating home-manager configurations.

