### PR TITLE
Replace deprecated --use-remote-sudo with --sudo

### DIFF
--- a/activate/activate.nu
+++ b/activate/activate.nu
@@ -106,8 +106,8 @@ def activate_system_local [ hostData: record, --dry-run=false ] {
         sudo darwin-rebuild $subcommand --flake $hostData.flake ...$hostData.outputs.nixArgs
     } else {
         let subcommand = if $dry_run { "dry-activate" } else { "switch" }
-        log info $"(ansi blue_bold)>>>(ansi reset) nixos-rebuild ($subcommand) --flake ($hostData.flake) ($hostData.outputs.nixArgs | str join) --use-remote-sudo "
-        nixos-rebuild $subcommand --flake $hostData.flake ...$hostData.outputs.nixArgs --use-remote-sudo
+        log info $"(ansi blue_bold)>>>(ansi reset) nixos-rebuild ($subcommand) --flake ($hostData.flake) ($hostData.outputs.nixArgs | str join) --sudo "
+        nixos-rebuild $subcommand --flake $hostData.flake ...$hostData.outputs.nixArgs --sudo
     }
 }
 


### PR DESCRIPTION
## Summary
- Replaces deprecated `--use-remote-sudo` flag with `--sudo` in nixos-rebuild command

## Test plan
- Verify nixos-rebuild activation works without deprecation warning