### PR TITLE
docs: fix output attribute

### DIFF
--- a/doc/guide/activate.md
+++ b/doc/guide/activate.md
@@ -24,7 +24,7 @@ nix run .#activate
 > ```nix
 > # In perSystem
 > {
->     packages.default = self'.packages.activate
+>     apps.default = self'.packages.activate
 > }
 > ```
 


### PR DESCRIPTION
According to the stated intention of being able to just `nix run` it, `apps` is the attribute to do so.

Hope that it helps!