### PR TITLE
fix: rename `runCommandNoCC` -> `runCommand`

### DIFF
--- a/activate/nu.nix
+++ b/activate/nu.nix
@@ -27,7 +27,7 @@
         '';
       };
     in
-    pkgs.runCommandNoCC name
+    pkgs.runCommand name
       {
         inherit meta;
       } ''

--- a/doc/history.md
+++ b/doc/history.md
@@ -16,6 +16,7 @@ order: 100
 - Remove use of deprecated alias `--update-input` of `nix flake update`
 - Use `sudo` when activating with nix-darwin (#130)
 - Fix `nix copy` command for legacy NixOS systems by adding experimental features flag (#138)
+- Switch to runCommand since runCommandNoCC is dropped in newer nixpkgs (#147)
 
 ## 0.2.0 (2024-10-03)
 


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/blob/061c55856b29b8b9360e14231a0986c7f85f1130/pkgs/top-level/aliases.nix#L1321