### PR TITLE
Add local NixOS sudo activation mode

### DIFF
--- a/activate/activate.nu
+++ b/activate/activate.nu
@@ -106,8 +106,14 @@ def activate_system_local [ hostData: record, --dry-run=false ] {
         sudo darwin-rebuild $subcommand --flake $hostData.flake ...$hostData.outputs.nixArgs
     } else {
         let subcommand = if $dry_run { "dry-activate" } else { "switch" }
-        log info $"(ansi blue_bold)>>>(ansi reset) nixos-rebuild ($subcommand) --flake ($hostData.flake) ($hostData.outputs.nixArgs | str join) --sudo "
-        nixos-rebuild $subcommand --flake $hostData.flake ...$hostData.outputs.nixArgs --sudo
+        if $hostData.localPrivilegeMode == "sudo-nixos-rebuild" {
+            let nixosRebuild = "/run/current-system/sw/bin/nixos-rebuild"
+            log info $"(ansi blue_bold)>>>(ansi reset) sudo ($nixosRebuild) ($subcommand) --flake ($hostData.flake) ($hostData.outputs.nixArgs | str join)"
+            sudo $nixosRebuild $subcommand --flake $hostData.flake ...$hostData.outputs.nixArgs
+        } else {
+            log info $"(ansi blue_bold)>>>(ansi reset) nixos-rebuild ($subcommand) --flake ($hostData.flake) ($hostData.outputs.nixArgs | str join) --sudo"
+            nixos-rebuild $subcommand --flake $hostData.flake ...$hostData.outputs.nixArgs --sudo
+        }
     }
 }
 

--- a/doc/guide/activate.md
+++ b/doc/guide/activate.md
@@ -18,6 +18,40 @@ In order to activate a system configuration for the current host (`$HOSTNAME`), 
 nix run .#activate
 ```
 
+### Passwordless local NixOS activation {#passwordless-local-nixos}
+
+By default, local NixOS activation runs `nixos-rebuild switch --sudo`, so
+`nixos-rebuild` decides when to invoke `sudo` for privileged steps.
+
+If you want sudoers to match a single command, configure the target host to run
+`nixos-rebuild` itself through sudo:
+
+```nix
+{
+  nixos-unified.localPrivilegeMode = "sudo-nixos-rebuild";
+}
+```
+
+This makes the activator run `/run/current-system/sw/bin/nixos-rebuild` via
+sudo. Add a narrowly scoped sudoers rule for the user and command you use for
+activation:
+
+```nix
+{
+  security.sudo.extraRules = [
+    {
+      users = [ "myuser" ];
+      commands = [
+        {
+          command = "/run/current-system/sw/bin/nixos-rebuild switch *";
+          options = [ "NOPASSWD" ];
+        }
+      ];
+    }
+  ];
+}
+```
+
 > [!TIP]
 > Usually, you'd make this your default package, so as to be able to use `nix run`. In `flake.nix`:
 >

--- a/doc/history.md
+++ b/doc/history.md
@@ -15,6 +15,7 @@ order: 100
   - Add a default `home.homeDirectory` based on the user's username (#117)
 - Remove use of deprecated alias `--update-input` of `nix flake update`
 - Use `sudo` when activating with nix-darwin (#130)
+- Add an opt-in local NixOS activation mode that runs `nixos-rebuild` itself through `sudo`
 - Fix `nix copy` command for legacy NixOS systems by adding experimental features flag (#138)
 - Switch to runCommand since runCommandNoCC is dropped in newer nixpkgs (#147)
 

--- a/nix/modules/configurations/default.nix
+++ b/nix/modules/configurations/default.nix
@@ -23,6 +23,20 @@ in
           List of flake inputs to override when deploying or activating.
         '';
       };
+      localPrivilegeMode = lib.mkOption {
+        type = lib.types.enum [ "nixos-rebuild-sudo" "sudo-nixos-rebuild" ];
+        default = "nixos-rebuild-sudo";
+        description = ''
+          How local NixOS activation obtains root privileges.
+
+          `nixos-rebuild-sudo` runs `nixos-rebuild` as the calling user with
+          `--sudo`, letting nixos-rebuild invoke sudo for privileged steps.
+
+          `sudo-nixos-rebuild` runs `nixos-rebuild` itself via sudo. This is
+          useful when sudoers should allow passwordless activation by matching a
+          single `nixos-rebuild` command.
+        '';
+      };
       outputs = {
         system = lib.mkOption {
           type = lib.types.str;


### PR DESCRIPTION
## Summary

- Add `nixos-unified.localPrivilegeMode` for local system activation privilege handling
- Keep the current `nixos-rebuild --sudo` behavior as the default
- Add an opt-in `sudo-nixos-rebuild` mode that runs `/run/current-system/sw/bin/nixos-rebuild` through sudo, so sudoers can match a stable command path
- Document passwordless local NixOS activation with a narrowly scoped sudoers rule

## Verification

- `nixpkgs-fmt nix/modules/configurations/default.nix`
- `nix build .#activate --override-input nixos-unified ../.. --no-link --print-out-paths` from `examples/linux`
