### PR TITLE
fix(doc): update emanote for docs build

### DIFF
--- a/doc/flake.lock
+++ b/doc/flake.lock
@@ -68,11 +68,11 @@
         "unionmount": "unionmount"
       },
       "locked": {
-        "lastModified": 1776891844,
-        "narHash": "sha256-r7KuquMAViG1DfsBz75K+foWHbna8JrZNDAfaDlDiWw=",
+        "lastModified": 1776963486,
+        "narHash": "sha256-/h+FEYZ7HiDnhDCrukLoVrRTLr2QOzbq4a0FdxeGilA=",
         "owner": "srid",
         "repo": "emanote",
-        "rev": "ecb8f6597c4254cc1e30934530651d4aec9ebc77",
+        "rev": "a2e697c4c5f6653495f20914cfd2f71deb9dc4c2",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "haskell-flake": {
       "locked": {
-        "lastModified": 1752499668,
-        "narHash": "sha256-Yif99ho8GNgXP0l9vxPHCKi7X16Cf7rwVd+HW1cMVeQ=",
+        "lastModified": 1776783293,
+        "narHash": "sha256-Na95Y2awqZsLhFNfBNbLj0hk4zyE3eKUROB2o9Qdqi8=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "39065472d2587af93a502423276bfb98c2c6fb09",
+        "rev": "f52ac89b2232dd50e5d1110416ebc5bbb09265bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- update `doc/flake.lock` to `srid/emanote@a2e697c4c5f6653495f20914cfd2f71deb9dc4c2`
- pull in the newer transitive `srid/haskell-flake@f52ac89b2232dd50e5d1110416ebc5bbb09265bd` through that upstream update

## Why

The docs GitHub Actions job failed at `cd doc && nix build` on April 23, 2026 in job `72738653367` because the older Emanote pin pulled a broken `kanwren/nix-parsec` fetch through its Haskell dependency chain.

## Verification

- `nix build ./doc -L --no-link`
